### PR TITLE
Linux/Mac Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+bin/
+
 .vs
 intermediates
 *.pdb

--- a/makefile
+++ b/makefile
@@ -1,0 +1,26 @@
+UNAME := $(shell uname)
+CC := gcc
+CXX := g++
+LIBS=-lRTMA
+
+ifeq ($(UNAME), Linux)
+COMMON=-O2 -I$(RTMA)/include -DUSE_LINUX -std=c++11 -pthread -Wl
+LIBEXT=.so
+endif
+
+ifeq ($(UNAME), Darwin)
+COMMON=-O2 -I$(RTMA)/include -DUSE_LINUX -std=c++11 -stdlib=libc++ -pthread
+LIBEXT=.dylib
+endif
+
+.PHONY: all
+all: bin/rtma_bench
+	rm build/*.o
+
+bin/rtma_bench: build/rtma_bench.o
+	$(CXX) $(COMMON) -L$(RTMA)/lib build/rtma_bench.o $(LIBS) -o bin/rtma_bench
+build/rtma_bench.o: src/rtma_bench.cpp
+	$(CXX) -c $(COMMON) src/rtma_bench.cpp -o build/rtma_bench.o
+clean:
+	rm build/*.o
+	rm bin/rtma_bench

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ CXX := g++
 LIBS=-lRTMA
 
 ifeq ($(UNAME), Linux)
-COMMON=-O2 -I$(RTMA)/include -DUSE_LINUX -std=c++11 -pthread -Wl
+COMMON=-O2 -I$(RTMA)/include -DUSE_LINUX -std=c++11 -pthread
 LIBEXT=.so
 endif
 

--- a/src/rtma_bench.cpp
+++ b/src/rtma_bench.cpp
@@ -1,4 +1,4 @@
-#include "rtma.h"
+#include "RTMA.h"
 
 #include <vector>
 #include <thread>


### PR DESCRIPTION
Added a makefile to compile rtma_bench on MacOS or Linux (tested on MacOS 10.14 and a Raspberry Pi 4 running Raspbian Buster).